### PR TITLE
Feature - ExifTool process management

### DIFF
--- a/src/common/exif_tool_processes.ts
+++ b/src/common/exif_tool_processes.ts
@@ -1,0 +1,17 @@
+import { ExiftoolProcess } from "node-exiftool";
+import { exiftoolBinPath } from "../common/binaries";
+import os from "os";
+
+export function spawnExifToolProcesses(
+	maxNumProcesses: number
+): ExiftoolProcess[] {
+	const numProcesses = Math.min(os.cpus().length, maxNumProcesses);
+
+	return [...Array(numProcesses)].map((n) => {
+		return newExifToolProcess();
+	});
+}
+
+function newExifToolProcess(): ExiftoolProcess {
+	return new ExiftoolProcess(exiftoolBinPath());
+}

--- a/src/main/dock.ts
+++ b/src/main/dock.ts
@@ -1,18 +1,26 @@
-import { BrowserWindow, app } from "electron";
+import { app } from "electron";
 import { isMac } from "../common/platform";
 import { ipcMain } from "electron";
 
 export const EVENT_FILES_ADDED = "files-added";
 export const EVENT_FILE_PROCESSED = "file-processed";
+export const EVENT_ALL_FILES_PROCESSED = "all-files-processed";
 
 export function setupDockEventHandlers(): void {
 	if (isMac()) {
 		ipcMain.on(EVENT_FILES_ADDED, (_event, filesCount) => {
+			// set counter when files added
 			updateDockFilesAdded(filesCount);
 		});
 
 		ipcMain.on(EVENT_FILE_PROCESSED, (_event, _arg) => {
+			// decrement counter when file finishes processing
 			updateDockRemovedFile();
+		});
+
+		ipcMain.on(EVENT_ALL_FILES_PROCESSED, (_event, _arg) => {
+			// bounce when done processing all files
+			updateDockBounce();
 		});
 	}
 }
@@ -37,9 +45,8 @@ function updateDockRemovedFile(): void {
 
 	// update badge count
 	app.dock.setBadge(displayFileCount);
+}
 
-	// bounce if done
-	if (newFileCount <= 0 && !BrowserWindow.getFocusedWindow()) {
-		app.dock.bounce("critical");
-	}
+function updateDockBounce(): void {
+	app.dock.bounce("critical");
 }

--- a/src/renderer/add_files.ts
+++ b/src/renderer/add_files.ts
@@ -19,7 +19,9 @@ export async function addFiles(
 			filePathsIterator,
 			exifToolProcess,
 			exifToolProcess.open()
-		);
+		).catch(() => {
+			exifToolProcess.close();
+		});
 	});
 
 	return Promise.all(promises);

--- a/src/renderer/add_files.ts
+++ b/src/renderer/add_files.ts
@@ -1,42 +1,70 @@
-import { updateRowWithCleanerSpinner } from "./table_update_row";
-import { addTableRow } from "./table_add_row";
+import { ExiftoolProcess } from "node-exiftool";
 import { ipcRenderer } from "electron";
 import { EVENT_FILE_PROCESSED, EVENT_FILES_ADDED } from "../main/dock";
+import { updateRowWithCleanerSpinner } from "./table_update_row";
+import { addTableRow } from "./table_add_row";
 import { removeExif } from "./exif_remove";
 import { displayExifBeforeClean, displayExifAfterClean } from "./display_exif";
-import { newExifToolProcess } from "./new_process";
 
-export async function addFiles({ filePaths }: { filePaths: string[] }) {
-	ipcRenderer.send(EVENT_FILES_ADDED, filePaths.length.toString());
+export async function addFiles(
+	filePaths: string[],
+	exifToolProcesses: ExiftoolProcess[]
+): Promise<any[]> {
+	ipcRenderer.send(EVENT_FILES_ADDED, filePaths.length);
 
+	const filePathsIterator = filePath(filePaths);
+
+	const promises = exifToolProcesses.map((exifToolProcess) => {
+		return processFile(
+			filePathsIterator,
+			exifToolProcess,
+			exifToolProcess.open()
+		);
+	});
+
+	return Promise.all(promises);
+}
+
+async function processFile(
+	filePathsIterator: Generator<string, void, unknown>,
+	exifToolProcess: ExiftoolProcess,
+	exifToolPromise: Promise<any>
+): Promise<any> {
+	exifToolPromise.then(() => {
+		const iteratorResult = filePathsIterator.next();
+		if (iteratorResult.done) {
+			return exifToolProcess.close();
+		}
+
+		const filePath = iteratorResult.value;
+		const promise = addFile(filePath, exifToolProcess);
+
+		return processFile(filePathsIterator, exifToolProcess, promise);
+	});
+}
+
+function* filePath(filePaths: string[]): Generator<string, any, unknown> {
 	for (const filePath of filePaths) {
-		addFile({ filePath: filePath });
+		yield filePath;
 	}
 }
 
-async function addFile({ filePath }: { filePath: string }): Promise<any> {
-	// add table row
-	const trNode = addTableRow({ filePath: filePath });
+async function addFile(
+	filePath: string,
+	exifToolProcess: ExiftoolProcess
+): Promise<void> {
+	const tableRow = addTableRow(filePath);
 
-	displayExifBeforeClean({ trNode: trNode, filePath: filePath })
-		.then(() => {
-			return updateRowWithCleanerSpinner({ trNode: trNode });
+	return displayExifBeforeClean(exifToolProcess, tableRow, filePath)
+		.then((exifData) => {
+			console.log(exifData);
+			updateRowWithCleanerSpinner(tableRow);
 		})
 		.then(() => {
-			const ep = newExifToolProcess();
-			return removeExif({ ep: ep, filePath: filePath }).then((val) => {
-				ep.close();
-				return val;
-			});
+			return removeExif(exifToolProcess, filePath);
 		})
 		.then(() => {
-			return displayExifAfterClean({ trNode: trNode, filePath: filePath });
-		})
-		.then(() => {
-			return new Promise(function (resolve) {
-				ipcRenderer.send(EVENT_FILE_PROCESSED);
-				resolve();
-			});
-		})
-		.catch(console.error);
+			ipcRenderer.send(EVENT_FILE_PROCESSED);
+			return displayExifAfterClean(exifToolProcess, tableRow, filePath);
+		});
 }

--- a/src/renderer/display_exif.ts
+++ b/src/renderer/display_exif.ts
@@ -1,52 +1,35 @@
 import { getExif } from "./exif_get";
 import { updateRowWithExif } from "./table_update_row";
-import { newExifToolProcess } from "./new_process";
+import { ExiftoolProcess } from "node-exiftool";
 
-export async function displayExifBeforeClean({
-	trNode,
-	filePath,
-}: {
-	trNode: HTMLTableRowElement;
-	filePath: string;
-}): Promise<any> {
+export async function displayExifBeforeClean(
+	exifToolProcess: ExiftoolProcess,
+	trNode: HTMLTableRowElement,
+	filePath: string
+): Promise<any> {
 	const tdBeforeNode = trNode.querySelector("td:nth-child(2)");
 	if (!(tdBeforeNode instanceof HTMLTableCellElement)) {
 		throw new Error("Expected table data cell element");
 	}
 
-	const ep = newExifToolProcess();
-	const exifData = await getExif({
-		exiftoolProcess: ep,
-		filePath: filePath,
-	}).then((val) => {
-		ep.close();
-		return val;
-	});
+	return getExif(exifToolProcess, filePath).then((exifData) => {
+		updateRowWithExif(tdBeforeNode, exifData);
 
-	updateRowWithExif({ tdNode: tdBeforeNode, exifData: exifData });
+		return exifData;
+	});
 }
 
-export async function displayExifAfterClean({
-	trNode,
-	filePath,
-}: {
-	trNode: HTMLTableRowElement;
-	filePath: string;
-}): Promise<any> {
+export async function displayExifAfterClean(
+	exifToolProcess: ExiftoolProcess,
+	trNode: HTMLTableRowElement,
+	filePath: string
+): Promise<any> {
 	const tdAfterNode = trNode.querySelector("td:nth-child(3)");
 	if (!(tdAfterNode instanceof HTMLTableCellElement)) {
 		throw new Error("Expected table data cell element");
 	}
 
-	const ep = newExifToolProcess();
-	const newExifData = await getExif({
-		exiftoolProcess: ep,
-		filePath: filePath,
-	}).then((val) => {
-		ep.close();
-		return val;
+	return getExif(exifToolProcess, filePath).then((exifDataAfterClean) => {
+		updateRowWithExif(tdAfterNode, exifDataAfterClean);
 	});
-
-	updateRowWithExif({ tdNode: tdAfterNode, exifData: newExifData });
-	return Promise.resolve();
 }

--- a/src/renderer/exif_get.ts
+++ b/src/renderer/exif_get.ts
@@ -8,34 +8,20 @@ const EXIFTOOL_ARGS_GET_EXIF = [
 
 // Read exif data using the ExifTool binary
 // and clean up after the process when done
-export async function getExif({
-	exiftoolProcess,
-	filePath,
-}: {
-	exiftoolProcess: ExiftoolProcess;
-	filePath: string;
-}): Promise<object> {
+export async function getExif(
+	exiftoolProcess: ExiftoolProcess,
+	filePath: string
+): Promise<object> {
 	const exifData = exiftoolProcess
-		.open()
-		// .then((pid) => console.log('Started exiftool process %s', pid))
-		.then(() => {
-			return exiftoolProcess
-				.readMetadata(filePath, EXIFTOOL_ARGS_GET_EXIF)
-				.then(
-					(exifData) => {
-						if (exifData.data === null) {
-							return {};
-						}
+		.readMetadata(filePath, EXIFTOOL_ARGS_GET_EXIF)
+		.then((exifData) => {
+			if (exifData.data === null) {
+				return {};
+			}
 
-						const hash = exifData.data[0];
-						return cleanExifDataOutput(hash);
-					}
-					// (err) => {
-					// 	console.error(err);
-					// }
-				);
+			const hash = exifData.data[0];
+			return cleanExifDataOutput(hash);
 		});
-	// .catch(console.error);
 
 	return exifData;
 }

--- a/src/renderer/exif_remove.ts
+++ b/src/renderer/exif_remove.ts
@@ -1,3 +1,5 @@
+import { ExiftoolProcess } from "node-exiftool";
+
 const EXIFTOOL_ARGS_REMOVE_EXIF = [
 	"charset filename=UTF8",
 	"overwrite_original",
@@ -5,36 +7,16 @@ const EXIFTOOL_ARGS_REMOVE_EXIF = [
 
 // The heart of the app, removing exif data from the image.
 // This uses the Perl binary "exiftool" the app's `.resources` dir
-//
-// Opening and Closing
-//
-// After creating an instance of ExiftoolProcess, it must be opened.
-// When finished working with it, it should be closed,
-// when -stay_open False will be written to its stdin to exit the process.
-//
-// import exiftool from "node-exiftool"
-// const ep = new exiftool.ExiftoolProcess()
-//
-// ep
-//   .open()
-//   // read and write metadata operations
-//   .then(() => ep.close())
-//   .then(() => console.log('Closed exiftool'))
-//   .catch(console.error)
-export async function removeExif({
-	ep,
-	filePath,
-}: {
-	ep: any;
-	filePath: string;
-}): Promise<object> {
-	const exifData = ep
-		.open()
-		// .then((pid) => console.log('Started exiftool process %s', pid))
-		.then(() => {
-			return ep.writeMetadata(filePath, { all: "" }, EXIFTOOL_ARGS_REMOVE_EXIF);
-		});
-	// .catch(console.error);
+export async function removeExif(
+	exifToolProcess: ExiftoolProcess,
+	filePath: string
+): Promise<object> {
+	const exifData = exifToolProcess.writeMetadata(
+		filePath,
+		{ all: "" },
+		EXIFTOOL_ARGS_REMOVE_EXIF,
+		false
+	);
 
 	return exifData;
 }

--- a/src/renderer/new_process.ts
+++ b/src/renderer/new_process.ts
@@ -1,9 +1,0 @@
-import { exiftoolBinPath } from "../common/binaries";
-import exiftool from "node-exiftool";
-
-export function newExifToolProcess(): exiftool.ExiftoolProcess {
-	const binPath = exiftoolBinPath();
-	const process = new exiftool.ExiftoolProcess(binPath);
-
-	return process;
-}

--- a/src/renderer/select_files.ts
+++ b/src/renderer/select_files.ts
@@ -1,15 +1,30 @@
+import { spawnExifToolProcesses } from "../common/exif_tool_processes";
 import { addFiles } from "./add_files";
 import { hideEmptyPane } from "./empty_pane";
 import {
 	showSelectedFilesPane,
 	eraseSelectedFilesPane,
 } from "./selected_files";
+import { ipcRenderer } from "electron";
+import { EVENT_FILE_PROCESSED } from "../main/dock";
 
 export function selectFiles(filePaths: string[]): void {
-	if (filePaths.length > 0) {
-		hideEmptyPane();
-		eraseSelectedFilesPane();
-		addFiles({ filePaths: filePaths });
-		showSelectedFilesPane();
+	if (filePaths.length == 0) {
+		return;
 	}
+
+	// show selected files display panel
+	hideEmptyPane();
+	eraseSelectedFilesPane();
+	showSelectedFilesPane();
+
+	processFiles(filePaths);
+}
+
+async function processFiles(filePaths: string[]): Promise<void> {
+	const exifToolProcesses = spawnExifToolProcesses(filePaths.length);
+
+	addFiles(filePaths, exifToolProcesses).finally(() => {
+		ipcRenderer.send(EVENT_FILE_PROCESSED);
+	});
 }

--- a/src/renderer/table_add_row.ts
+++ b/src/renderer/table_add_row.ts
@@ -1,11 +1,7 @@
 import path from "path";
 import { selectedFilesList } from "./selected_files";
 
-export function addTableRow({
-	filePath,
-}: {
-	filePath: string;
-}): HTMLTableRowElement {
+export function addTableRow(filePath: string): HTMLTableRowElement {
 	const label = path.basename(filePath);
 
 	// tr node

--- a/src/renderer/table_update_row.ts
+++ b/src/renderer/table_update_row.ts
@@ -1,10 +1,7 @@
-export function updateRowWithExif({
-	tdNode,
-	exifData,
-}: {
-	tdNode: HTMLTableDataCellElement;
-	exifData: any;
-}): void {
+export function updateRowWithExif(
+	tdNode: HTMLTableDataCellElement,
+	exifData: any
+): void {
 	// td
 	tdNode.textContent = "";
 
@@ -43,11 +40,7 @@ function buildExifString({ exifData }: { exifData: any }): string {
 	return str;
 }
 
-export function updateRowWithCleanerSpinner({
-	trNode,
-}: {
-	trNode: HTMLTableRowElement;
-}): void {
+export function updateRowWithCleanerSpinner(trNode: HTMLTableRowElement): void {
 	// td
 	const tdNode = trNode.querySelector("td:nth-child(3)");
 	if (!tdNode) {

--- a/src/types/node-exiftool/index.d.ts
+++ b/src/types/node-exiftool/index.d.ts
@@ -3,7 +3,9 @@
 // for used methods from the public interface
 
 declare module "node-exiftool" {
-	import { Readable } from "stream";
+	import { Readable, Writable } from "stream";
+
+	type ExifToolPid = number;
 
 	export class ExiftoolProcess {
 		constructor(bin: string);
@@ -12,11 +14,18 @@ declare module "node-exiftool" {
 
 		close(): Promise<{ success: any; error: Error }>;
 
-		open(encoding?: string, options?: object): Promise<number>;
+		open(encoding?: string, options?: object): Promise<ExifToolPid>;
 
 		readMetadata(
 			file: string | Readable,
 			args: string[]
+		): Promise<{ data: object[] | null; error: string | null }>;
+
+		writeMetadata(
+			file: string | Writable,
+			metadata: object,
+			extraArgs: string[],
+			debug: boolean
 		): Promise<{ data: object[] | null; error: string | null }>;
 
 		// 	writeMetadata(...args: any[]): void;


### PR DESCRIPTION
Limit concurrency to number of CPUs, and reuse ExifTool processes. Leads to massive speed increase when processing multiple files. Also, close processes on exception.

Fixes https://github.com/szTheory/exifcleaner/issues/24