### PR TITLE
Use of app.dock only in macOS

### DIFF
--- a/src/main/dock.ts
+++ b/src/main/dock.ts
@@ -72,5 +72,5 @@ function updateProgressBar(browserWindow: BrowserWindow | null): void {
 }
 
 function updateDockBounce(): void {
-	app.dock.bounce("critical");
+	if (isMac()) app.dock.bounce("critical");
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -29,5 +29,5 @@ function dockMenu(): Menu {
 
 export function setupMenu(): void {
 	Menu.setApplicationMenu(menu());
-	app.dock.setMenu(dockMenu());
+	if (isMac()) app.dock.setMenu(dockMenu());
 }


### PR DESCRIPTION
Methods app.dock.setMenu in menu.ts and app.dock.bounce in dock.ts are called only on macOS.

fix #75 