### PR TITLE
New: Implemented GitHub actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
               with:
-                  name: Gitify-dist-mac
+                  name: Gitify-dist-Mac
                   path: dist/*.dmg
 
     build-windows:
@@ -49,6 +49,7 @@ jobs:
 
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
+              name: Gitify-dist-Win
               with:
                   path: dist/*.exe
 
@@ -74,6 +75,7 @@ jobs:
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
               with:
+                  name: Gitify-dist-Linux
                   path: |
                       dist/*.AppImage
                       dist/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
               run: yarn update-exiftool
 
             - name: Build
-              run: yarn packmac
+              run: yarn packmac --publish never
 
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
@@ -45,7 +45,7 @@ jobs:
               run: yarn update-exiftool
 
             - name: Build
-              run: yarn packwin
+              run: yarn packwin --publish never
 
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
@@ -69,7 +69,7 @@ jobs:
               run: yarn update-exiftool
 
             - name: Build
-              run: yarn packlinux
+              run: yarn packlinux --publish never
 
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
 
             - name: Upload artifacts to GitHub
               uses: actions/upload-artifact@v2
-              name: Gitify-dist-Win
               with:
+                  name: Gitify-dist-Win
                   path: dist/*.exe
 
     build-linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore yarn cache
-            - uses: actions/setup-node@v2
+              uses: actions/setup-node@v2
               with:
                   cache: "yarn"
 
@@ -35,7 +35,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore yarn cache
-            - uses: actions/setup-node@v2
+              uses: actions/setup-node@v2
               with:
                   cache: "yarn"
 
@@ -48,7 +48,7 @@ jobs:
               run: yarn packwin
 
             - name: Upload artifacts to GitHub
-            - uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v2
               with:
                   path: dist/*.exe
 
@@ -59,7 +59,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore yarn cache
-            - uses: actions/setup-node@v2
+              uses: actions/setup-node@v2
               with:
                   cache: "yarn"
 
@@ -72,7 +72,7 @@ jobs:
               run: yarn packlinux
 
             - name: Upload artifacts to GitHub
-            - uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v2
               with:
                   path: |
                       dist/*.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+    build-macos:
+        runs-on: macos-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Restore yarn cache
+            - uses: actions/setup-node@v2
+              with:
+                  cache: "yarn"
+
+            - name: Install Dependencies
+              run: yarn install
+            - name: Update ExifTool
+              run: yarn update-exiftool
+
+            - name: Build
+              run: yarn packmac
+
+            - name: Upload artifacts to GitHub
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: Gitify-dist-mac
+                  path: dist/*.dmg
+
+    build-windows:
+        runs-on: windows-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Restore yarn cache
+            - uses: actions/setup-node@v2
+              with:
+                  cache: "yarn"
+
+            - name: Install Dependencies
+              run: yarn install
+            - name: Update ExifTool
+              run: yarn update-exiftool
+
+            - name: Build
+              run: yarn packwin
+
+            - name: Upload artifacts to GitHub
+            - uses: actions/upload-artifact@v2
+              with:
+                  path: dist/*.exe
+
+    build-linux:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Restore yarn cache
+            - uses: actions/setup-node@v2
+              with:
+                  cache: "yarn"
+
+            - name: Install Dependencies
+              run: yarn install
+            - name: Update ExifTool
+              run: yarn update-exiftool
+
+            - name: Build
+              run: yarn packlinux
+
+            - name: Upload artifacts to GitHub
+            - uses: actions/upload-artifact@v2
+              with:
+                  path: |
+                      dist/*.AppImage
+                      dist/*.deb
+                      dist/*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
               run: yarn packmac
 
             - name: Upload artifacts to GitHub
-            - uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v2
               with:
                   name: Gitify-dist-mac
                   path: dist/*.dmg

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Restore yarn cache
-      - uses: actions/setup-node@v2
+        uses: actions/setup-node@v2
         with:
           cache: "yarn"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Restore yarn cache
+      - uses: actions/setup-node@v2
+        with:
+          cache: "yarn"
+
+      - name: Install Dependencies
+        run: yarn install
+      - name: Update ExifTool
+        run: yarn update-exiftool
+
+      - name: Lint
+        run: yarn lint

--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,7 @@ yarn-error.log
 # Explicitly include Travis CI configuration 
 # that were being hit by the .gitignore rule .*
 !.travis.yml
+
+# Explicitly include GitHub configuration 
+# that were being hit by the .gitignore rule .*
+!.github/


### PR DESCRIPTION
Hi, I just implemented the GitHub actions CI to this repo.
IMO, that's better than Trevis CI because it's better integration with GitHub.
Now, there are two main problems with this pull request:
- The Lint CI fails, it says basically that every file has styling issues ([Here you can check the workflow run](https://github.com/blackcat-917/exifcleaner/runs/3519667035)). I think that's Prettier's fault because whenever I tried to run `yarn format` on my ArchLinux machine and it gives me the same errors that the CI is giving. Maybe tweaking a bit with the `.prettierrc` configuration file can fix the issue.
- The `update_exiftool.pl` doesn't check if the version installed of ExifTool is the latest, so every time the CI runs it has to download it from the exiftool.org site, I think that this is a useless bandwidth waste. My proposal to resolve this issue would be inserting some kind of check in the Perl script to test if the version downloaded is the latest and then cache the ExifTool files to reuse between one CI run and another (I already know how to implement the latter).
Maybe I could try to implement a solution in the CI workflow but that would be more complicated than what I proposed (and also won't work if the runner isn't the CI).

Sorry for my bad English