### PR TITLE
fix: replace the settings gear with a symmetric, concentric icon

### DIFF
--- a/src/renderer/components/icons/GearIcon.tsx
+++ b/src/renderer/components/icons/GearIcon.tsx
@@ -22,8 +22,20 @@ export const GearIcon = React.forwardRef<
 				strokeLinecap="round"
 				strokeLinejoin="round"
 			>
-				<circle cx="8" cy="8" r="2.5" />
-				<path d="M6.69 1.74a.94.94 0 0 1 .93-.74h.76a.94.94 0 0 1 .93.74l.17.83a5.2 5.2 0 0 1 .86.5l.8-.27a.94.94 0 0 1 1.05.38l.38.66a.94.94 0 0 1-.12 1.12l-.63.56a5.3 5.3 0 0 1 0 1l.63.56a.94.94 0 0 1 .12 1.12l-.38.66a.94.94 0 0 1-1.05.38l-.8-.27a5.2 5.2 0 0 1-.86.5l-.17.83a.94.94 0 0 1-.93.74h-.76a.94.94 0 0 1-.93-.74l-.17-.83a5.2 5.2 0 0 1-.86-.5l-.8.27a.94.94 0 0 1-1.05-.38l-.38-.66a.94.94 0 0 1 .12-1.12l.63-.56a5.3 5.3 0 0 1 0-1l-.63-.56A.94.94 0 0 1 3.43 4l.38-.66a.94.94 0 0 1 1.05-.38l.8.27a5.2 5.2 0 0 1 .86-.5l.17-.83Z" />
+				{/*
+				  8-tooth gear generated on a polar grid about (8,8), so the hub is
+				  concentric with the body by construction rather than by hand-tuned arc
+				  parameters. The previous path was neither symmetric nor centred: its body
+				  spanned y 1.00-11.04 (centre 6.02) against a hub at y=8, so the hub sat
+				  ~2 units low and the bottom third of the frame was empty.
+
+				  Tips at r=7.0, roots at r=5.0, hub r=2.4. Tip radius plus half the 1.5
+				  stroke reaches 7.66, inside the 8-unit half-frame, so nothing clips.
+				  Corners are softened by stroke-linejoin="round", which is why the outline
+				  is a plain polygon needing no arc commands.
+				*/}
+				<circle cx="8" cy="8" r="2.4" />
+				<path d="M6.85 1.09L9.15 1.09L8.82 3.07L10.91 3.93L12.07 2.3L13.7 3.93L12.07 5.09L12.93 7.18L14.91 6.85L14.91 9.15L12.93 8.82L12.07 10.91L13.7 12.07L12.07 13.7L10.91 12.07L8.82 12.93L9.15 14.91L6.85 14.91L7.18 12.93L5.09 12.07L3.93 13.7L2.3 12.07L3.93 10.91L3.07 8.82L1.09 9.15L1.09 6.85L3.07 7.18L3.93 5.09L2.3 3.93L3.93 2.3L5.09 3.93L7.18 3.07Z" />
 			</svg>
 		</button>
 	);


### PR DESCRIPTION
The settings cog's hub was visibly off-centre. Measuring the path rather than eyeballing it: the body spans `y 1.00–11.04` (centre **6.02**) against a hub fixed at `y=8`, so the hub sits **~2 units low** in a 16-unit frame, the bottom third is empty, and the teeth are uneven — the arc parameters were hand-tuned rather than derived.

Replaced with geometry generated on a polar grid about `(8,8)`, so concentricity is structural rather than something to hand-tune correctly.

**Selection.** Six candidates rendered and compared at true 16px, where the differences that matter appear: 6-tooth and deep-root variants read as flowers; shallow teeth mush into a scalloped ring; an odd tooth count loses mirror symmetry about the vertical axis. The 8-tooth (tips r=7.0, roots r=5.0, hub r=2.4) variant keeps distinct teeth and an open hub at 16px in both light and dark.

**Verified numerically, not just visually:**

- 32 vertices, zero duplicates
- bounding-box centre exactly `(8.000, 8.000)`, matching the hub
- max reach 7.66 including half the 1.5 stroke — inside the 8-unit half-frame, so nothing clips

An intermediate version collapsed both root points onto the same angle, producing a 32-point star with 16 duplicate vertices that only looked like a gear because `stroke-linejoin="round"` hid the coincident points. The generator now emits flat tips, radial flanks, and flat roots.

Local: lint, typecheck, 46 E2E — all green.