### PR TITLE
fix(32): pin Windows release asset names

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,9 +136,13 @@
 			]
 		},
 		"nsis": {
+			"artifactName": "${productName}.Setup.${version}.${ext}",
 			"oneClick": true,
 			"perMachine": false,
 			"runAfterFinish": false
+		},
+		"portable": {
+			"artifactName": "${productName}.${version}.${ext}"
 		},
 		"win": {
 			"target": [

--- a/tests/scripts/release_asset_gate.test.ts
+++ b/tests/scripts/release_asset_gate.test.ts
@@ -76,6 +76,24 @@ afterEach(() => {
 });
 
 describe("release asset gate", () => {
+	test("pins Windows builder output to the public asset contract", () => {
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.resolve("package.json"), "utf8"),
+		) as {
+			build?: {
+				nsis?: { artifactName?: string };
+				portable?: { artifactName?: string };
+			};
+		};
+
+		expect(packageJson.build?.nsis?.artifactName).toBe(
+			"${productName}.Setup.${version}.${ext}",
+		);
+		expect(packageJson.build?.portable?.artifactName).toBe(
+			"${productName}.${version}.${ext}",
+		);
+	});
+
 	test("builds a byte-derived manifest for the exact native release set", () => {
 		const bundle = createBundle();
 


### PR DESCRIPTION
## Summary
- pin NSIS and portable artifact templates to the documented/public dotted names
- add a regression test binding electron-builder configuration to the release asset contract

## Why
Trusted promotion failed closed before tag/release mutation because electron-builder produced space-delimited Windows filenames while RELEASE_NOTES.md, the validator, and the prior public release use dotted names.

## Verification
- `yarn vitest run tests/scripts/release_asset_gate.test.ts` (red before, 5/5 green after)
- `yarn verify:release` (64 files, 568 tests; all composed gates green)

This PR remains read-only; successful protected CI will auto-merge it, after which final-SHA CI will retry trusted promotion automatically.