### PR TITLE
Stabilize Electron startup timing in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,8 @@ const isCI = process.env["CI"] !== undefined;
 export default defineConfig({
 	testDir: "./tests/e2e",
 	testMatch: "*.spec.ts",
-	timeout: 15000,
+	// Hosted runners need extra headroom for a cold Electron launch.
+	timeout: isCI ? 60_000 : 15_000,
 	retries: 0,
 	// The app holds an OS-level single-instance lock, so two workers launching
 	// it concurrently would deadlock. This is a constraint, not a tuning knob.

--- a/tests/e2e/helpers/app_launcher.ts
+++ b/tests/e2e/helpers/app_launcher.ts
@@ -8,6 +8,7 @@ import type { Settings } from "../../../src/domain/settings_schema";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const APP_LAUNCH_TIMEOUT_MS = process.env["CI"] === undefined ? 15_000 : 30_000;
 
 export async function launchApp(options?: {
 	settings?: Partial<Settings>;
@@ -48,7 +49,7 @@ export async function launchApp(options?: {
 			// (not the Electron.app bundle). The compiled output in out/ is still used.
 			NODE_ENV: "development",
 		},
-		timeout: 15000,
+		timeout: APP_LAUNCH_TIMEOUT_MS,
 	});
 	const window = await app.firstWindow();
 	await window.waitForLoadState("domcontentloaded");


### PR DESCRIPTION
The hosted Ubuntu runner intermittently spends the full 15-second test budget starting Electron, so the orientation mutation gate fails before reaching its controlled assertion.

This keeps local fail-fast timing unchanged while allowing CI 30 seconds for Electron startup and 60 seconds for the complete test.

Verified locally with `CI=1`: mutation gate passed, 600 unit tests passed, 68 E2E tests passed, lint/typecheck/dependency checks passed.